### PR TITLE
Generate dragons controller + index + basic bootstrap view

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -41,7 +41,9 @@
   z-index: 2;
   background: black;
   opacity: 0;
-}
-.card-dragon-link:hover {
+
+  &:hover {
   opacity: 0.1;
+  }
 }
+

--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -1,0 +1,47 @@
+.card {
+  height: 175px;
+  text-shadow: 0 1px 3px rgba(0,0,0,0.6);
+  background-size: cover !important;
+  background-position: center;
+  color: white;
+  position: relative;
+  margin: 5px;
+  border-radius: 5px;
+  text-align: left;
+}
+.card-dragon-name {
+  font-size: 24px;
+  position: absolute;
+  top: 0px;
+  left: 8px;
+  margin-top: 15px !important;
+  font-weight: normal;
+}
+.card-dragon-attributes {
+  padding: 0px !important;
+  font-size: 14px;
+  opacity: 0.7;
+  font-weight: lighter;
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+}
+.card-dragon-price{
+  font-size: 18px;
+  position: absolute;
+  bottom: 30px;
+  right: 8px;
+}
+.card-dragon-link {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  z-index: 2;
+  background: black;
+  opacity: 0;
+}
+.card-dragon-link:hover {
+  opacity: 0.1;
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -1,3 +1,4 @@
 // Import your components CSS files here.
 @import "alert";
 @import "navbar";
+@import "card";

--- a/app/controllers/dragons_controller.rb
+++ b/app/controllers/dragons_controller.rb
@@ -1,0 +1,8 @@
+class DragonsController < ApplicationController
+  skip_before_action :authenticate_user!, only: :index
+
+  def index
+    @dragons = Dragon.all
+  end
+
+end

--- a/app/models/dragon.rb
+++ b/app/models/dragon.rb
@@ -6,5 +6,38 @@ class Dragon < ApplicationRecord
   validates :name, presence: true
   validates :price, presence: true
   validates :price, numericality: { only_integer: true }
-  validates :temperament, inclusion: {in: (0..5)}
+  validates :temperament, inclusion: {in: (0..4)}
+  validates :size, inclusion: {in: (0..4)}
+
+  def describe_temperament
+    case self.temperament
+    when 0
+      return "Cuddly"
+    when 1
+      return "Well-mannered"
+    when 2
+      return "Docile"
+    when 3
+      return "Insatible"
+    when 4
+      return "Ferocious"
+    end
+  end
+
+  def describe_size
+    case self.size
+    when 0
+      return "Tiny"
+    when 1
+      return "Small"
+    when 2
+      return "Mid-sized"
+    when 3
+      return "Big"
+    when 4
+      return "Giant"
+    end
+  end
+
+
 end

--- a/app/views/dragons/index.html.erb
+++ b/app/views/dragons/index.html.erb
@@ -1,0 +1,28 @@
+<div class="container">
+  <h1>Dragons</h1>
+  <div class="row">
+    <% @dragons.each do |dragon| %>
+      <div class="col-xs-12 col-md-3">
+        <div class="card" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.2))">
+          <h2 class="card-dragon-name">
+            <%= dragon.name %>
+          </h2>
+          <ul class="card-dragon-attributes">
+            <li>
+              <%= dragon.describe_temperament %>
+            </li>
+            <li>
+              <%= dragon.describe_size %>
+            </li>
+          </ul>
+          <h4 class="card-dragon-price">
+            <%= "#{dragon.price} $/night"%>
+          </h4>
+          <%= link_to "", "#", class: "card-dragon-link" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<!-- add dragon_path(dragon) in the card link:to -->

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -6,13 +6,11 @@
 
   <!-- Right Navigation -->
   <div class="navbar-wagon-right hidden-xs hidden-sm">
+    <%= link_to "Dragons", dragons_path, class: "navbar-wagon-item navbar-wagon-link" %>
 
     <% if user_signed_in? %>
 
       <!-- Links when logged in -->
-      <%= link_to "Host", "#", class: "navbar-wagon-item navbar-wagon-link" %>
-      <%= link_to "Trips", "#", class: "navbar-wagon-item navbar-wagon-link" %>
-      <%= link_to "Messages", "#", class: "navbar-wagon-item navbar-wagon-link" %>
 
       <!-- Avatar with dropdown menu -->
       <div class="navbar-wagon-item">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
+
+  resources :dragons, only: [:index]
+
   root to: 'pages#home'
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 2018_08_13_150829) do
     t.string "color"
     t.integer "size"
     t.text "diet"
-    t.integer "temperament", default: 2
+    t.integer "temperament"
     t.boolean "fire"
     t.string "location"
     t.integer "price"

--- a/test/controllers/dragons_controller_test.rb
+++ b/test/controllers/dragons_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class DragonsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Looks like this:
<img width="1280" alt="schermata 2018-08-13 alle 18 20 12" src="https://user-images.githubusercontent.com/39303357/44044333-8eed7762-9f25-11e8-9e9e-b9b8ce50df18.png">

I'm translating the numeric values for size and temperament with two methods in dragon.rb.
I added a validation for size to be included in (0..4).
I added the topbar link to the dragon index.
The card link and the background image (at the moment it's just the gradient overlay that we can keep) will need to be updated.