### PR TITLE
Feature/profile page/display owned dragons

### DIFF
--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -1,2 +1,3 @@
 // Import page-specific CSS files here.
 @import "home";
+@import "profile";

--- a/app/assets/stylesheets/pages/_profile.scss
+++ b/app/assets/stylesheets/pages/_profile.scss
@@ -1,0 +1,29 @@
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+  grid-template-rows: 400px 400px 400px;
+}
+
+.user-info {
+  background-color: red;
+  grid-row: 1 / span 1;
+  grid-column: 1 / span 2;
+}
+
+.user-message {
+  background-color: green;
+  grid-row: 1 / span 1;
+  grid-column: 3 / span 3;
+}
+
+.user-owned-dragons {
+  background-color: yellow;
+  grid-row: 2 / span 1;
+  grid-column: 1 / span 5;
+}
+
+.user-bookings {
+  background-color: blue;
+  grid-row: 3 / span 1;
+  grid-column: 1 / span 5;
+}

--- a/app/assets/stylesheets/pages/_profile.scss
+++ b/app/assets/stylesheets/pages/_profile.scss
@@ -8,22 +8,73 @@
   background-color: red;
   grid-row: 1 / span 1;
   grid-column: 1 / span 2;
+  margin: 5px;
+  padding: 10px;
 }
 
 .user-message {
   background-color: green;
   grid-row: 1 / span 1;
   grid-column: 3 / span 3;
+  margin: 5px;
+  padding: 10px;
 }
 
 .user-owned-dragons {
   background-color: yellow;
   grid-row: 2 / span 1;
   grid-column: 1 / span 5;
+  margin: 5px;
+  padding: 10px;
 }
 
 .user-bookings {
   background-color: blue;
   grid-row: 3 / span 1;
   grid-column: 1 / span 5;
+  margin: 5px;
+  padding: 10px;
+}
+
+
+// Grid display for mobile devices and smaller screen
+
+@media(max-width: 720px) {
+  .grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: 400px 400px 400px 400px;
+  }
+
+  .user-info {
+    background-color: red;
+    grid-row: 1 / span 1;
+    grid-column: 1 / span 1;
+    margin-bottom: 10px;
+    padding: 10px;
+  }
+
+  .user-message {
+    background-color: green;
+    grid-row: 2 / span 1;
+    grid-column: 1 / span 1;
+    margin-bottom: 10px;
+    padding: 10px;
+  }
+
+  .user-owned-dragons {
+    background-color: yellow;
+    grid-row: 3 / span 1;
+    grid-column: 1 / span 1;
+    margin-bottom: 10px;
+    padding: 10px;
+  }
+
+  .user-bookings {
+    background-color: blue;
+    grid-row: 4 / span 1;
+    grid-column: 1 / span 1;
+    margin-bottom: 10px;
+    padding: 10px;
+  }
 }

--- a/app/controllers/profile_controller.rb
+++ b/app/controllers/profile_controller.rb
@@ -1,6 +1,8 @@
 class ProfileController < ApplicationController
   def show
     @user = current_user
+    @owned_dragons = Dragon.where(owner: @user)
+    @bookings = Dragon.where(renters: @user)
   end
 
 end

--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -1,30 +1,116 @@
 <!-- NOTE: this page is diplayed as a grid -->
 <div class="container">
-    <h1>My profile</h1>
+  <h1>My profile</h1>
 
-<div class="grid">
-  <div class="user-info">
-    <h2>My personal info</h2>
-    <!-- USER AVATAR -->
-    <%= cl_image_tag @user.photo, class: 'avatar-large' %>
+  <div class="grid">
+    <div class="user-info">
+      <h2>My personal info</h2>
+      <!-- USER AVATAR -->
+      <%= cl_image_tag @user.photo, class: 'avatar-large' %>
 
-    <!-- USER INFO -->
-    <p>user name: <%= @user.name %></p>
-    <p>user email: <%= @user.email %></p>
+      <!-- USER INFO -->
+      <p>user name: <%= @user.name %></p>
+      <p>user email: <%= @user.email %></p>
 
-    <%= link_to 'Edit my profile', edit_user_registration_path  %>
+      <%= link_to 'Edit my profile', edit_user_registration_path  %>
+    </div>
+
+    <div class="user-message">
+      <h2>My messages</h2>
+      <% if !@bookings.empty? %>
+
+        <ul class="inbox">
+          <% @bookings.each do |booking| %>
+          <li class="message">
+            <%= cl_image_tag(booking.user.photo) %>
+            <div class="message-name">
+              <h3><%= booking.user.name %></h3>
+              <p>from <%= booking.start_date %> until <%= booking.end_date %></p>
+            </div>
+            <div class="message-body">
+              <p><strong>I am not sure yet!</strong></p>
+              <p>
+                I am not sure yet! I might be in Shanghai at this moment... Can I tell you later?
+              </p>
+            </div>
+            <div class="message-status">
+              <p><%= booking.status %></p>
+              <% number_days = end_date - start_date %>
+              <p class="price"><%= number_days * booking.dragon.price %></p>
+            </div>
+          </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p>You don't have any booking request</p>
+      <% end %>
+    </div>
+
+    <div class="user-owned-dragons">
+      <h2>My dragons</h2>
+      <% if @dragons_owned %>
+
+      <div class="row">
+        <% @dragons_owned.each do |dragon| %>
+        <div class="col-xs-12 col-md-3">
+          <div class="card" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.2))">
+            <h2 class="card-dragon-name">
+              <%= dragon.name %>
+            </h2>
+            <ul class="card-dragon-attributes">
+              <li>
+                <%= dragon.describe_temperament %>
+              </li>
+              <li>
+                <%= dragon.describe_size %>
+              </li>
+            </ul>
+            <h4 class="card-dragon-price">
+              <%= "#{dragon.price} $/night"%>
+            </h4>
+            <%= link_to "", "#", class: "card-dragon-link" %>
+          </div>
+        </div>
+        <% end %>
+      </div>
+
+      <% else %>
+      <p>You don't have any dragons</p>
+      <% end %>
+    </div>
+
+    <div class="user-bookings">
+      <h2>My bookings</h2>
+
+      <% if !@bookings.empty? %>
+
+      <div class="row">
+        <% @bookings.each do |booking| %>
+        <div class="col-xs-12 col-md-3">
+          <div class="card" style="background-image: linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.2))">
+            <h2 class="card-dragon-name">
+              <%= dragon.name %>
+            </h2>
+            <ul class="card-dragon-attributes">
+              <li>
+                <%= dragon.describe_temperament %>
+              </li>
+              <li>
+                <%= dragon.describe_size %>
+              </li>
+            </ul>
+            <h4 class="card-dragon-price">
+              <%= "#{dragon.price} $/night"%>
+            </h4>
+            <%= link_to "", "#", class: "card-dragon-link" %>
+          </div>
+        </div>
+        <% end %>
+      </div>
+
+      <% else %>
+      <p>You don't have any booking</p>
+      <% end %>
+    </div>
   </div>
-
-<div class="user-message">
-  <h2>My messages</h2>
-</div>
-
-  <div class="user-owned-dragons">
-<h2>My dragons</h2>
-  </div>
-
-  <div class="user-bookings">
-    <h2>My bookings</h2>
-  </div>
-</div>
 </div>

--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -1,12 +1,30 @@
+<!-- NOTE: this page is diplayed as a grid -->
 <div class="container">
-  <h1>My profile</h1>
+    <h1>My profile</h1>
 
-  <!-- USER AVATAR -->
-  <%= cl_image_tag @user.photo, class: 'avatar-large' %>
+<div class="grid">
+  <div class="user-info">
+    <h2>My personal info</h2>
+    <!-- USER AVATAR -->
+    <%= cl_image_tag @user.photo, class: 'avatar-large' %>
 
-  <!-- USER INFO -->
-  <p>user name: <%= @user.name %></p>
-  <p>user email: <%= @user.email %></p>
+    <!-- USER INFO -->
+    <p>user name: <%= @user.name %></p>
+    <p>user email: <%= @user.email %></p>
 
-  <%= link_to 'Edit my profile', edit_user_registration_path  %>
+    <%= link_to 'Edit my profile', edit_user_registration_path  %>
+  </div>
+
+<div class="user-message">
+  <h2>My messages</h2>
+</div>
+
+  <div class="user-owned-dragons">
+<h2>My dragons</h2>
+  </div>
+
+  <div class="user-bookings">
+    <h2>My bookings</h2>
+  </div>
+</div>
 </div>


### PR DESCRIPTION
Here is the pull request for the following features on profile page:
- create grid display:
       1. Personal info
       2. Messages (booking requests for owned dragons)
       3. List of owned dragons
       4. List of booking request for other dragons
- display either list of cards of owned dragons or message "you don't have any dragons" if empty
- same for booking request for other dragons
- same for booking requests for owned dragons

For the moment, I only tested with unpopulated db so nothing was displayed except the empty messages