### PR TITLE
fix wrong url for images

### DIFF
--- a/app/uploaders/dragon_photo_uploader.rb
+++ b/app/uploaders/dragon_photo_uploader.rb
@@ -2,7 +2,7 @@ class DragonPhotoUploader < CarrierWave::Uploader::Base
   include Cloudinary::CarrierWave
 
   def default_public_id
-   'dinosaur.png'
+   'v1534235813/dinosaur'
   end
 end
 

--- a/app/uploaders/photo_uploader.rb
+++ b/app/uploaders/photo_uploader.rb
@@ -2,6 +2,6 @@ class PhotoUploader < CarrierWave::Uploader::Base
   include Cloudinary::CarrierWave
 
   def default_public_id
-   'user-silhouette.png'
+   'v1534235817/user-silhouette'
   end
 end


### PR DESCRIPTION
Urls for the images now lead to the correct URL. To find, use .photo_url