### PR TITLE
Fix/empty search

### DIFF
--- a/app/controllers/dragons_controller.rb
+++ b/app/controllers/dragons_controller.rb
@@ -1,78 +1,78 @@
 class DragonsController < ApplicationController
   skip_before_action :authenticate_user!, only: [:index, :show]
   before_action :set_dragon, only: [:show, :edit, :update, :destroy]
+  # before_action :set_markers, only: [:index]
 
   def index
-
-
-    # if params[:query].present?
-      @dragons = Dragon.where.not(latitude: nil, longitude: nil)
-      @markers = @dragons.map do |flat|
-        {
-          lat: flat.latitude,
-        lng: flat.longitude#,
+    if params[:address].present?
+      @dragons = Dragon.where('address ILIKE ?', "#{params[:address]}")
+      @query = params[:address]
+      @markers = @dragons.map do |dragon|
+      {
+      lat: dragon.latitude,
+      lng: dragon.longitude#,
         # infoWindow: { content: render_to_string(partial: "/flats/map_box", locals: { flat: flat }) }
-        }
-      # end
-      # @query = params[:query]
-    # else
-    #   @dragons = Dragon.all
+      }
+      end
+    else
+      @dragons = Dragon.all
     end
   end
 
-def show
-  if @dragon.booked_by?(current_user)
-    @booking = current_user.bookings.where(dragon: @dragon).last
-  else
-    @booking = Booking.new
+  def show
+    if @dragon.booked_by?(current_user)
+      @booking = current_user.bookings.where(dragon: @dragon).last
+    else
+      @booking = Booking.new
+    end
   end
-end
 
-def new
-  @dragon = Dragon.new
-end
-
-def create
-  @dragon = Dragon.new(dragon_params)
-  @dragon.owner = current_user
-  if @dragon.save
-    redirect_to dragons_path
-  else
-    render :new
+  def new
+    @dragon = Dragon.new
   end
-end
 
-def edit
-
-end
-
-def update
-  @dragon.owner = current_user
-  if @dragon.update(dragon_params)
-    redirect_to profile_path(@dragon.owner)
-  else
-    render :new
+  def create
+    @dragon = Dragon.new(dragon_params)
+    @dragon.owner = current_user
+    if @dragon.save
+      redirect_to dragons_path
+    else
+      render :new
+    end
   end
-end
 
-def destroy
-  @dragon.owner = current_user
-  if @dragon.destroy
-    redirect_to profile_path(@dragon.owner)
-  else
-    render :new
+  def edit
+
   end
-end
 
-private
+  def update
+    @dragon.owner = current_user
+    if @dragon.update(dragon_params)
+      redirect_to profile_path(@dragon.owner)
+    else
+      render :new
+    end
+  end
 
-def dragon_params
-  params.require(:dragon).permit(:name, :color, :size, :diet, :temperament, :fire, :address, :price, :description, :photo, :photo_cache)
-end
+  def destroy
+    @dragon.owner = current_user
+    if @dragon.destroy
+      redirect_to profile_path(@dragon.owner)
+    else
+      render :new
+    end
+  end
 
-def set_dragon
-  @dragon = Dragon.find(params[:id])
-end
+  private
+
+  def dragon_params
+    params.require(:dragon).permit(:name, :color, :size, :diet, :temperament, :fire, :address, :price, :description, :photo, :photo_cache)
+  end
+
+  def set_dragon
+    @dragon = Dragon.find(params[:id])
+  end
+
 end
 
 

--- a/app/controllers/dragons_controller.rb
+++ b/app/controllers/dragons_controller.rb
@@ -1,21 +1,15 @@
 class DragonsController < ApplicationController
   skip_before_action :authenticate_user!, only: [:index, :show]
   before_action :set_dragon, only: [:show, :edit, :update, :destroy]
-  # before_action :set_markers, only: [:index]
 
   def index
     if params[:address].present?
       @dragons = Dragon.where('address ILIKE ?', "#{params[:address]}")
       @query = params[:address]
-      @markers = @dragons.map do |dragon|
-      {
-      lat: dragon.latitude,
-      lng: dragon.longitude#,
-        # infoWindow: { content: render_to_string(partial: "/flats/map_box", locals: { flat: flat }) }
-      }
-      end
+      set_markers
     else
       @dragons = Dragon.all
+      set_markers
     end
   end
 
@@ -73,6 +67,11 @@ class DragonsController < ApplicationController
     @dragon = Dragon.find(params[:id])
   end
 
+  def set_markers
+    @markers = @dragons.map do |dragon|
+      dragon.markers
+    end
+  end
 end
 
 

--- a/app/javascript/packs/map.js
+++ b/app/javascript/packs/map.js
@@ -372,6 +372,17 @@ if (mapElement) { // don't try to build a map if there's no div#map to inject in
   const map = new GMaps({ el: '#map', lat: 0, lng: 0, styles: styles });
   const markers = JSON.parse(mapElement.dataset.markers);
   map.addMarkers(markers);
+
+  // var infowindow = new google.maps.InfoWindow({
+  //   content: contentString
+  // });
+
+  // markers.forEach(function(marker) {
+  //   marker.addListener('click', function() {
+  //   infowindow.open(map, marker);
+  //   })
+  // });
+
   if (markers.length === 0) {
     map.setZoom(2);
   } else if (markers.length === 1) {

--- a/app/models/dragon.rb
+++ b/app/models/dragon.rb
@@ -6,16 +6,17 @@ class Dragon < ApplicationRecord
   has_many :bookings, dependent: :destroy
   has_many :renters, through: :bookings, source: :user
 
-
-
   validates :name, presence: true
   validates :price, presence: true
   validates :price, numericality: { only_integer: true }
   validates :temperament, inclusion: {in: (0..4)}
   validates :size, inclusion: {in: (0..4)}
 
-
   mount_uploader :photo, DragonPhotoUploader
+
+  def markers
+    {lat: self.latitude, lng: self.longitude}
+  end
 
   def describe_temperament
     case self.temperament

--- a/app/views/bookings/show.html.erb
+++ b/app/views/bookings/show.html.erb
@@ -10,7 +10,7 @@
       <div class="show-booking-details">
         <h4>From: <%= @booking.start_date %></h4>
         <h4>for <%= @booking.total_duration %> days</h4>
-        <h4>In <%= @booking.dragon.location %></h4>
+        <h4>In <%= @booking.dragon.address %></h4>
         <h4>Status: <%= @booking.status %></h4>
         <h4>Total: <%= @booking.total_price %>€</h4>
       </div>

--- a/app/views/dragons/index.html.erb
+++ b/app/views/dragons/index.html.erb
@@ -1,19 +1,19 @@
 <!-- Changes the title of the page according to the results (with location name, or empty) -->
 <% if @query.present? && !@dragons.empty? %>
-<h2><%= "Dragons in #{@query.capitalize}" %></h2>
-<% elsif @dragons.empty? %>
-<div class="empty-search-results col-xs-12 col-md-4 col-md-offset-4">
-  <h2>No dragons here!</h2>
-  <%= image_tag "search.jpg" %>
-</div>
+  <h2>  <%="Dragons in #{@query.capitalize}"%> </h2>
+  <% elsif @dragons.empty? %>
+  <div class="empty-search-results col-xs-12 col-md-4 col-md-offset-4">
+    <h2>No dragons here!</h2>
+    <%= image_tag "search.jpg" %>
+  </div>
 <% end %>
 
 <!-- Displays all the dragons in cards -->
 <div class="cover-all-container">
   <div class="card-dragon-container">
     <% @dragons.each do |dragon| %>
-    <% if dragon.id.odd? %>
-    <div class="card-dragon-whole-white_odd">
+      <% if dragon.id.odd? %>
+      <div class="card-dragon-whole-white_odd">
       <h2 class="card-dragon-name_odd">
         <%= dragon.name %>
       </h2>
@@ -30,7 +30,7 @@
         <%= "#{dragon.price} $/day"%>
       </h4>
       <%= link_to "", dragon_path(dragon), class: "card-dragon-link" %>
-    </div>
+      </div>
     <% end %>
 
 
@@ -61,15 +61,17 @@
     </div>
     <% end %>
     <% end %>
-
-
-</div>
-<div class="map-dragon", id="map"
-style="width: 100%",
-data-markers="<%= @markers.to_json %>">
-<%= image_tag 'grey.jpg' %>
-</div>
   </div>
+
+  <% if @dragons.present? %>
+    <div class="map-dragon", id="map"
+    style="width: 100%",
+    data-markers="<%= @markers.to_json %>"
+    <%= image_tag 'grey.jpg' %>
+    </div>
+  <% end %>
+
+</div>
 
 
 

--- a/app/views/dragons/show.html.erb
+++ b/app/views/dragons/show.html.erb
@@ -15,7 +15,7 @@
           <%= cl_image_tag @dragon.owner.photo_url, class: 'avatar' %>
           <p> Owner: <%= @dragon.owner.name %></p>
         </div>
-        <p> In: <%= @dragon.location %> </p>
+        <p> In: <%= @dragon.address %> </p>
         <ul class="dragon-attributes">
           <li class="dragon-bullet-attributes">
             <i class="fas fa-exclamation-circle"></i>

--- a/app/views/profile/show.html.erb
+++ b/app/views/profile/show.html.erb
@@ -95,7 +95,7 @@
                 <%= booking.total_duration %> days
               </li>
               <li>
-                in <%= booking.dragon.location %>
+                in <%= booking.dragon.address %>
               </li>
             </ul>
             <div class="booking-delete">

--- a/db/migrate/20180816093429_remove_location_from_dragons.rb
+++ b/db/migrate/20180816093429_remove_location_from_dragons.rb
@@ -1,0 +1,5 @@
+class RemoveLocationFromDragons < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :dragons, :location, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_15_111355) do
+ActiveRecord::Schema.define(version: 2018_08_16_093429) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,7 +34,6 @@ ActiveRecord::Schema.define(version: 2018_08_15_111355) do
     t.text "diet"
     t.integer "temperament"
     t.boolean "fire"
-    t.string "location"
     t.integer "price"
     t.bigint "user_id"
     t.datetime "created_at", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -87,7 +87,7 @@ Dragon.create!([
     diet: "In 1802, a Norwegian Ridgeback is reported to have carried off a Whale Calf off the coast of Norway.",
     temperament: 0,
     fire: true,
-    address: "Berlin",
+    address: "Paris",
     price: 10,
     user_id: 3,
     description: "The Norwegian Ridgeback is a dragon native to Norway, and its typical habitat is the Northern mountains. It was said to physically resemble a Hungarian Horntail. It resembles the Hungarian Horntail, except for the black ridges on its back, the browner texture in its scales, and its less hostile attitude. It has venomous fangs, and its food of choice is large mammals, including water mammals, which is unusual for a dragon. Its eggs are black, and young Ridgebacks develop the ability to shoot flame earlier than any other breeds (around one to three months). Female Ridgebacks are generally more ferocious than the males."
@@ -99,7 +99,7 @@ Dragon.create!([
     diet: "His diet consists of the gold treasure it protects from the greedy dwarves",
     temperament: 2,
     fire: true,
-    address: "Berlin",
+    address: "Paris",
     price: 180,
     user_id: 4,
     description: "The Ukrainian Ironbelly is a species of dragon native to Ukraine. It is said to be the largest dragon species in the world. Ironbellies have been subject to constant observation by the Ukrainian wizarding authorities, ever since a particular Ironbelly carried off a sailing ship from the Black Sea in 1799. Thankfully, the boat was empty at the time. "
@@ -111,7 +111,7 @@ Dragon.create!([
     diet: "Feeds mostly on fish in great quantity",
     temperament: 1,
     fire: true,
-    address: "Berlin",
+    address: "London",
     price: 160,
     user_id: 5,
     description: "Toothless has a rather large scar on his right shoulder/neck which is around a foot in length with a width of about an inch. Toothless's eyes are a bright green, sometimes acid or emerald green. They are located very near the front of his face giving him excellent depth perception and reflexes in flight. He can narrow his pupils to slits when threatened or angry, similar to that of a cat. However, when he is docile or happy, his pupils dilate and become more dog-like. Toothless gets his name from his ability to retract his teeth. While in Alpha Mode, Toothless has blue markings on his back, fins, spines, and forehead, glowing because of the fire. His nostrils glow, too."


### PR DESCRIPTION
- User can search by the new address field
- Dragon index shows only the dragons in the location searched for
- The map displays only the markers of the dragons in the location searched for
- The empty result screen is fixed
- Added a method to Dragon to set its markers (so we can place a single dragon in the map by using dragon.markers)
- Replaced all the only "dragon.location" with "dragon.address"
- Added a migration to remove the location column from the dragon table